### PR TITLE
Embed migration files and read them at runtime

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -6,12 +6,11 @@ import (
 )
 
 type DbConfig struct {
-	Host          string `toml:"host"`
-	Port          int    `toml:"port"`
-	Username      string `toml:"username"`
-	Password      string `toml:"password"`
-	Schema        string `toml:"schema"`
-	MigrationPath string `toml:"migration-path"`
+	Host     string `toml:"host"`
+	Port     int    `toml:"port"`
+	Username string `toml:"username"`
+	Password string `toml:"password"`
+	Schema   string `toml:"schema"`
 }
 
 type HeartConfig struct {

--- a/core/config/gen-localhost/main.go
+++ b/core/config/gen-localhost/main.go
@@ -18,12 +18,11 @@ func genLocalhostConfig() {
 	cfg.SisuServerUrl = "http://0.0.0.0:25456"
 
 	cfg.Db = config.DbConfig{
-		Host:          "0.0.0.0",
-		Port:          3306,
-		Username:      "root",
-		Password:      "password",
-		Schema:        "dheart",
-		MigrationPath: "file://db/migrations/",
+		Host:     "0.0.0.0",
+		Port:     3306,
+		Username: "root",
+		Password: "password",
+		Schema:   "dheart",
 	}
 
 	configFilePath := filepath.Join(cfg.HomeDir, "./dheart.toml")

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -1,0 +1,55 @@
+package db
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+//go:embed migrations/*
+var migrationsFS embed.FS
+
+// MigrationsTempDir creates a temporary directory, populates it with the migration files,
+// and returns the path to that directory.
+// This is useful to run database migrations with only the dheart binary,
+// without having to ship around the migration files separately.
+//
+// It is the caller's repsonsibility to remove the directory when it is no longer needed.
+func MigrationsTempDir() (string, error) {
+	tmpDir, err := os.MkdirTemp("", "dheart-migrations-*")
+	if err != nil {
+		return "", err
+	}
+
+	mFS, err := fs.Sub(migrationsFS, "migrations")
+	if err != nil {
+		return "", err
+	}
+
+	if err := fs.WalkDir(mFS, ".", func(path string, d fs.DirEntry, _ error) error {
+		dst := filepath.Join(tmpDir, path)
+		if dst == tmpDir {
+			return nil
+		}
+
+		if d.IsDir() {
+			if err := os.Mkdir(dst, 0700); err != nil {
+				return fmt.Errorf("failed to mkdir %q: %w", dst, err)
+			}
+			return nil
+		}
+
+		content, err := migrationsFS.ReadFile(filepath.Join("migrations", path))
+		if err != nil {
+			return err
+		}
+
+		return os.WriteFile(dst, content, 0600)
+	}); err != nil {
+		return "", err
+	}
+
+	return tmpDir, nil
+}

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -1,0 +1,54 @@
+package db_test
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sisu-network/dheart/db"
+)
+
+func TestMigrationsTempDir(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, err := db.MigrationsTempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Running with go test sets the working directory to the parent of the test source file,
+	// so we can just directly read from disk at this path.
+	onDiskFS := os.DirFS("./migrations")
+
+	// Walk the on-disk FS and ensure the FS returned by db.MigrationsTempDir
+	// matches exactly.
+	if err := fs.WalkDir(onDiskFS, ".", func(path string, d fs.DirEntry, _ error) error {
+		if d.IsDir() {
+			// Nothing to validate.
+			return nil
+		}
+
+		// Read the walked path from disk.
+		onDiskContent, err := os.ReadFile(filepath.Join(".", "migrations", path))
+		if err != nil {
+			t.Fatalf("failed to source migration file at path %q: %v", path, err)
+		}
+
+		// Compare with the file inside the temporary directory.
+		tmpContent, err := os.ReadFile(filepath.Join(tmpDir, path))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(onDiskContent, tmpContent) {
+			t.Fatalf("contents differed for path %q", path)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/e2e/core-heart/keygen/main.go
+++ b/test/e2e/core-heart/keygen/main.go
@@ -72,7 +72,6 @@ func main() {
 
 	dbConfig := config.GetLocalhostDbConfig()
 	dbConfig.Schema = fmt.Sprintf("dheart%d", index)
-	dbConfig.MigrationPath = "file://../../../../db/migrations/"
 
 	cfg := config.HeartConfig{
 		UseOnMemory: false,

--- a/test/e2e/core-heart/presign/main.go
+++ b/test/e2e/core-heart/presign/main.go
@@ -86,7 +86,6 @@ func main() {
 
 	dbConfig := config.GetLocalhostDbConfig()
 	dbConfig.Schema = fmt.Sprintf("dheart%d", index)
-	dbConfig.MigrationPath = "file://../../../../db/migrations/"
 
 	cfg := config.HeartConfig{
 		UseOnMemory: false,

--- a/test/e2e/db/main.go
+++ b/test/e2e/db/main.go
@@ -102,12 +102,11 @@ func testInsertingPresignData(database db.Database) {
 
 func main() {
 	config := &config.DbConfig{
-		Port:          3306,
-		Host:          "localhost",
-		Username:      "root",
-		Password:      "password",
-		Schema:        "dheart",
-		MigrationPath: "file://../../../db/migrations/",
+		Port:     3306,
+		Host:     "localhost",
+		Username: "root",
+		Password: "password",
+		Schema:   "dheart",
 	}
 
 	database := db.NewDatabase(config)

--- a/test/e2e/engine-keysign/main.go
+++ b/test/e2e/engine-keysign/main.go
@@ -93,7 +93,6 @@ func resetDb(dbConfig config.DbConfig) error {
 func getDb(index int) db.Database {
 	dbConfig := config.GetLocalhostDbConfig()
 	dbConfig.Schema = fmt.Sprintf("dheart%d", index)
-	dbConfig.MigrationPath = "file://../../../db/migrations/"
 
 	resetDb(dbConfig)
 


### PR DESCRIPTION
Instead of requiring an operator to copy the migration files around with
the dheart executable, use go:embed so they are available at runtime. As
far as I can see, the golang-migrate expects to read them from disk; so
instead of changing how that library works, simply copy the embedded
files to a temporary directory when running migrations.

Closes #20.